### PR TITLE
Add disk-backed lazy GIF IO, migrate image parallelism to QtConcurrent, and basic rectangle/ellipse drawing tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets LinguistTools)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets LinguistTools)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Concurrent LinguistTools)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets Concurrent LinguistTools)
 
 add_definitions(-DWINGGIF_VERSION="${PROJECT_VERSION}"
                 -DAPP_ORG="WingCloudStudio" -DAPP_NAME="${PROJECT_NAME}")
@@ -234,11 +234,11 @@ target_include_directories(
 
 if(WINGGIF_USE_FRAMELESS)
     target_link_libraries(
-        WingGifEditor2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets gif_object_lib
+        WingGifEditor2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Concurrent gif_object_lib
                                QWKCore QWKWidgets OpenMP::OpenMP_CXX)
 else()
     target_link_libraries(
-        WingGifEditor2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets gif_object_lib
+        WingGifEditor2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Concurrent gif_object_lib
                                OpenMP::OpenMP_CXX)
 endif()
 

--- a/src/class/gifcontentmodel.cpp
+++ b/src/class/gifcontentmodel.cpp
@@ -17,12 +17,11 @@
 
 #include "gifcontentmodel.h"
 
-#ifdef Q_OS_WIN
-#include <ppl.h>
-#endif
+#include <QDir>
+#include <QtConcurrent>
 
 GifContentModel::GifContentModel(QObject *parent)
-    : QAbstractListModel(parent) {}
+    : QAbstractListModel(parent), _frameCache(64) {}
 
 void GifContentModel::setLinkedListView(QListView *view) {
     if (view) {
@@ -48,10 +47,66 @@ void GifContentModel::updateLinkedListViewCurrent() const {
     }
 }
 
+bool GifContentModel::ensureStoreDir() {
+    if (_storeDir && _storeDir->isValid()) {
+        return true;
+    }
+    _storeDir = std::make_unique<QTemporaryDir>();
+    return _storeDir->isValid();
+}
+
+QString GifContentModel::framePathForIndex(qsizetype index) const {
+    if (!_storeDir || !_storeDir->isValid()) {
+        return {};
+    }
+    return _storeDir->path() + QDir::separator() +
+           QStringLiteral("model_%1.png").arg(index, 6, 10, QLatin1Char('0'));
+}
+
+void GifContentModel::persistFrame(qsizetype index, const QImage &image) {
+    if (!ensureStoreDir()) {
+        return;
+    }
+
+    if (_frameFiles.size() <= index) {
+        _frameFiles.resize(index + 1);
+    }
+
+    const auto framePath = framePathForIndex(index);
+    image.save(framePath, "PNG");
+    _frameFiles[index] = framePath;
+    _frameCache.insert(index, new QImage(image));
+}
+
+QImage GifContentModel::loadFrame(qsizetype index) const {
+    if (index < 0 || index >= _frameFiles.size()) {
+        return {};
+    }
+    if (auto cached = _frameCache.object(index)) {
+        return *cached;
+    }
+    QImage img;
+    img.load(_frameFiles.at(index));
+    if (!img.isNull()) {
+        _frameCache.insert(index, new QImage(img));
+    }
+    return img;
+}
+
 void GifContentModel::readGifReader(GifReader *reader) {
     if (reader) {
-        _data = reader->images();
+        clearData();
+        _frameSize = QSize(reader->width(), reader->height());
         _delays = reader->delays();
+        _frameFiles.resize(reader->imageCount());
+        if (!ensureStoreDir()) {
+            return;
+        }
+
+        for (qsizetype i = 0; i < reader->imageCount(); ++i) {
+            auto img = reader->image(i);
+            persistFrame(i, img);
+        }
         emit layoutChanged();
     }
 }
@@ -65,15 +120,23 @@ bool GifContentModel::insertFrame(const QImage &image, int delay, int index) {
         return false;
     }
 
-    beginInsertRows(QModelIndex(), index, index);
-    if (_data.isEmpty()) {
-        _data.insert(index, image);
+    auto allImages = images();
+    auto img = image;
+    if (!_frameSize.isEmpty()) {
+        img = image.scaled(_frameSize, Qt::IgnoreAspectRatio,
+                           Qt::SmoothTransformation);
     } else {
-        _data.insert(index,
-                     image.scaled(_data.first().size(), Qt::IgnoreAspectRatio,
-                                  Qt::SmoothTransformation));
+        _frameSize = image.size();
     }
+
+    allImages.insert(index, img);
+
+    beginInsertRows(QModelIndex(), index, index);
     _delays.insert(index, delay);
+    _frameFiles.insert(index, QString());
+    for (qsizetype i = 0; i < allImages.size(); ++i) {
+        persistFrame(i, allImages.at(i));
+    }
     endInsertRows();
     return true;
 }
@@ -87,11 +150,10 @@ void GifContentModel::insertFrames(const QVector<GifData> &frames, int index) {
             continue;
         }
 
-        if (_data.isEmpty()) {
+        if (_frameSize.isEmpty()) {
             imgs.append(f.image);
         } else {
-            imgs.append(f.image.scaled(_data.first().size(),
-                                       Qt::IgnoreAspectRatio,
+            imgs.append(f.image.scaled(_frameSize, Qt::IgnoreAspectRatio,
                                        Qt::SmoothTransformation));
         }
         delays.append(f.delay);
@@ -110,13 +172,6 @@ void GifContentModel::insertFrames(const QVector<QImage> &images,
                                    bool processed) {
     if (images.size() != delays.size()) {
         return;
-    }
-
-    if (index < 0) {
-        beginInsertRows(QModelIndex(), this->frameCount(),
-                        this->frameCount() + images.size());
-    } else {
-        beginInsertRows(QModelIndex(), index, index + images.size());
     }
 
     QVector<QImage> n_imgs;
@@ -138,20 +193,36 @@ void GifContentModel::insertFrames(const QVector<QImage> &images,
         n_delays = delays;
     }
 
-    if (index < 0) {
-        _data.append(n_imgs);
-        _delays.append(delays);
-    } else {
-        auto total = n_imgs.size();
-        _data.insert(index, total, QImage());
-        _delays.insert(index, total, 0);
+    if (n_imgs.isEmpty()) {
+        return;
+    }
 
-        for (int i = 0; i < total; ++i) {
-            _data.replace(i + index, n_imgs.at(i));
-            _delays.replace(i + index, _delays.at(i));
+    if (_frameSize.isEmpty()) {
+        _frameSize = n_imgs.first().size();
+    }
+
+    for (auto &img : n_imgs) {
+        if (img.size() != _frameSize) {
+            img = img.scaled(_frameSize, Qt::IgnoreAspectRatio,
+                             Qt::SmoothTransformation);
         }
     }
 
+    auto allImages = this->images();
+    auto insertPos = index < 0 ? frameCount() : index;
+    for (int i = 0; i < n_imgs.size(); ++i) {
+        allImages.insert(insertPos + i, n_imgs.at(i));
+    }
+
+    beginInsertRows(QModelIndex(), insertPos, insertPos + n_imgs.size() - 1);
+    _frameFiles.insert(insertPos, n_imgs.size(), QString());
+    _delays.insert(insertPos, n_delays.size(), 0);
+    for (int i = 0; i < n_delays.size(); ++i) {
+        _delays[insertPos + i] = n_delays.at(i);
+    }
+    for (qsizetype i = 0; i < allImages.size(); ++i) {
+        persistFrame(i, allImages.at(i));
+    }
     endInsertRows();
 }
 
@@ -159,7 +230,7 @@ bool GifContentModel::isValidGifFrame(const QImage &image, int delay) {
     if (image.isNull()) {
         return false;
     }
-    if (delay <= 0 && delay > delayLimitMax()) {
+    if (delay <= 0 || delay > delayLimitMax()) {
         return false;
     }
     return true;
@@ -170,91 +241,108 @@ int GifContentModel::delayLimitMin() { return 10; }
 int GifContentModel::delayLimitMax() { return 65530; }
 
 void GifContentModel::removeFrames(int index, qsizetype count) {
+    auto allImages = images();
     if (count < 0) {
         beginRemoveRows(QModelIndex(), index, this->frameCount() - 1);
+        allImages.erase(allImages.begin() + index, allImages.end());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        _data.erase(_data.cbegin() + index, _data.cend());
+        _frameFiles.erase(_frameFiles.cbegin() + index, _frameFiles.cend());
         _delays.erase(_delays.cbegin() + index, _delays.cend());
 #else
-        _data.erase(_data.begin() + index, _data.end());
+        _frameFiles.erase(_frameFiles.begin() + index, _frameFiles.end());
         _delays.erase(_delays.begin() + index, _delays.end());
 #endif
     } else {
         beginRemoveRows(QModelIndex(), index, index + count - 1);
-        _data.remove(index, count);
+        allImages.remove(index, count);
+        _frameFiles.remove(index, count);
         _delays.remove(index, count);
+    }
+
+    _frameCache.clear();
+    for (qsizetype i = 0; i < allImages.size(); ++i) {
+        persistFrame(i, allImages.at(i));
+    }
+
+    if (_frameFiles.isEmpty()) {
+        _frameSize = QSize();
     }
 
     endRemoveRows();
 }
 
 void GifContentModel::clearData() {
-    _data.clear();
+    _frameFiles.clear();
     _delays.clear();
+    _frameSize = QSize();
+    _frameCache.clear();
+    _storeDir.reset();
     emit layoutChanged();
 }
 
-QImage GifContentModel::image(qsizetype index) const { return _data.at(index); }
+QImage GifContentModel::image(qsizetype index) const { return loadFrame(index); }
 
 int GifContentModel::delay(qsizetype index) const { return _delays.at(index); }
 
 int GifContentModel::width() const {
-    if (_data.isEmpty()) {
+    if (_frameSize.isEmpty()) {
         return -1;
     }
-    return _data.first().width();
+    return _frameSize.width();
 }
 
 int GifContentModel::height() const {
-    if (_data.isEmpty()) {
+    if (_frameSize.isEmpty()) {
         return -1;
     }
-    return _data.first().height();
+    return _frameSize.height();
 }
 
 QSize GifContentModel::frameSize() const { return QSize(width(), height()); }
 
 QVector<int> GifContentModel::delays() const { return _delays; }
 
-QVector<QImage> GifContentModel::images() const { return _data; }
+QVector<QImage> GifContentModel::images() const {
+    QVector<QImage> imgs;
+    imgs.reserve(_frameFiles.size());
+    for (qsizetype i = 0; i < _frameFiles.size(); ++i) {
+        imgs.append(loadFrame(i));
+    }
+    return imgs;
+}
 
-qsizetype GifContentModel::frameCount() const { return _data.size(); }
+qsizetype GifContentModel::frameCount() const { return _frameFiles.size(); }
 
 void GifContentModel::swapFrames(const QVector<QImage> &imgs) {
-    Q_ASSERT(imgs.size() == _data.size());
-    _data = imgs;
-    emit dataChanged(this->index(0), this->index(_data.size() - 1));
+    Q_ASSERT(imgs.size() == _frameFiles.size());
+    for (qsizetype i = 0; i < imgs.size(); ++i) {
+        persistFrame(i, imgs.at(i));
+    }
+    emit dataChanged(this->index(0), this->index(_frameFiles.size() - 1));
     updateLinkedListViewCurrent();
 }
 
 void GifContentModel::cropFrames(const QRect &rect) {
     Q_ASSERT(rect.isValid());
-    if (_data.isEmpty()) {
+    if (_frameFiles.isEmpty()) {
         return;
     }
-    Q_ASSERT(_data.first().rect().contains(rect));
 
-#ifdef Q_OS_WIN
-    concurrency::parallel_for_each(
-        _data.begin(), _data.end(),
-        [rect](QImage &img) { img = img.copy(rect); });
-#else
-#pragma omp parallel for
-    for (auto &img : _data) {
-        img = img.copy(rect);
+    auto imgs = images();
+    QtConcurrent::blockingMap(imgs, [rect](QImage &img) { img = img.copy(rect); });
+
+    _frameSize = rect.size();
+    for (qsizetype i = 0; i < imgs.size(); ++i) {
+        persistFrame(i, imgs.at(i));
     }
-#endif
 
-    emit dataChanged(this->index(0), this->index(_data.size() - 1));
+    emit dataChanged(this->index(0), this->index(_frameFiles.size() - 1));
     updateLinkedListViewCurrent();
 }
 
-void GifContentModel::setFrameDelay(qsizetype index, int delay,
-                                    qsizetype count) {
+void GifContentModel::setFrameDelay(qsizetype index, int delay, qsizetype count) {
     Q_ASSERT(count != 0);
     if (count < 0) {
-
-#pragma omp parallel for
         for (qsizetype i = index; i < _delays.size(); ++i) {
             _delays.replace(i, delay);
         }
@@ -263,7 +351,6 @@ void GifContentModel::setFrameDelay(qsizetype index, int delay,
     } else {
         auto total = qMin(index + count, qsizetype(_delays.size()));
 
-#pragma omp parallel for
         for (qsizetype i = index; i < total; ++i) {
             _delays.replace(i, delay);
         }
@@ -273,14 +360,20 @@ void GifContentModel::setFrameDelay(qsizetype index, int delay,
 }
 
 bool GifContentModel::setFrameImage(qsizetype index, const QImage &img) {
-    if (index < 0 || index > _data.size()) {
+    if (index < 0 || index > _frameFiles.size()) {
         return false;
     }
     if (img.isNull()) {
         return false;
     }
-    _data.replace(index, img.scaled(frameSize(), Qt::IgnoreAspectRatio,
-                                    Qt::SmoothTransformation));
+    auto scaled = _frameSize.isEmpty()
+                      ? img
+                      : img.scaled(frameSize(), Qt::IgnoreAspectRatio,
+                                   Qt::SmoothTransformation);
+    if (_frameSize.isEmpty()) {
+        _frameSize = scaled.size();
+    }
+    persistFrame(index, scaled);
     updateLinkedListViewCurrent();
 
     return true;
@@ -288,76 +381,64 @@ bool GifContentModel::setFrameImage(qsizetype index, const QImage &img) {
 
 void GifContentModel::scaleFrames(int width, int height) {
     Q_ASSERT(width > 0 && height > 0);
-    if (_data.isEmpty()) {
+    if (_frameFiles.isEmpty()) {
         return;
     }
 
-#ifdef Q_OS_WIN
-    concurrency::parallel_for_each(
-        _data.begin(), _data.end(), [width, height](QImage &img) {
-            img = img.scaled(width, height, Qt::IgnoreAspectRatio,
-                             Qt::SmoothTransformation);
-        });
-#else
-#pragma omp parallel for
-    for (auto &img : _data) {
+    auto imgs = images();
+    QtConcurrent::blockingMap(imgs, [width, height](QImage &img) {
         img = img.scaled(width, height, Qt::IgnoreAspectRatio,
                          Qt::SmoothTransformation);
-    }
-#endif
+    });
 
-    emit dataChanged(this->index(0), this->index(_data.size() - 1));
+    _frameSize = QSize(width, height);
+    for (qsizetype i = 0; i < imgs.size(); ++i) {
+        persistFrame(i, imgs.at(i));
+    }
+
+    emit dataChanged(this->index(0), this->index(_frameFiles.size() - 1));
     updateLinkedListViewCurrent();
 }
 
-void GifContentModel::flipFrames(Qt::Orientation dir, int index,
-                                 qsizetype count) {
+void GifContentModel::flipFrames(Qt::Orientation dir, int index, qsizetype count) {
+    Q_UNUSED(index);
+    Q_UNUSED(count);
+
+    auto imgs = images();
     switch (dir) {
-    case Qt::Horizontal: {
-#ifdef Q_OS_WIN
-        concurrency::parallel_for_each(
-            _data.begin(), _data.end(),
-            [](QImage &img) { img = img.mirrored(true, false); });
-#else
-#pragma omp parallel for
-        for (auto &img : _data) {
-            img = img.mirrored(true, false);
-        }
-#endif
+    case Qt::Horizontal:
+        QtConcurrent::blockingMap(imgs,
+                                  [](QImage &img) { img = img.mirrored(true, false); });
+        break;
+    case Qt::Vertical:
+        QtConcurrent::blockingMap(imgs,
+                                  [](QImage &img) { img = img.mirrored(); });
         break;
     }
-    case Qt::Vertical: {
-#ifdef Q_OS_WIN
-        concurrency::parallel_for_each(
-            _data.begin(), _data.end(),
-            [](QImage &img) { img = img.mirrored(); });
-#else
-#pragma omp parallel for
-        for (auto &img : _data) {
-            img = img.mirrored();
-        }
-#endif
-        break;
+
+    for (qsizetype i = 0; i < imgs.size(); ++i) {
+        persistFrame(i, imgs.at(i));
     }
-    }
-    emit dataChanged(this->index(0), this->index(_data.size() - 1));
+
+    emit dataChanged(this->index(0), this->index(_frameFiles.size() - 1));
 }
 
 void GifContentModel::reverseFrames(qsizetype begin, qsizetype end) {
-    if ((end > 0 && end <= begin) || begin < 0 || end >= _data.size()) {
+    if ((end > 0 && end <= begin) || begin < 0 || end >= _frameFiles.size()) {
         return;
     }
     if (end < 0) {
-        std::reverse(std::next(_data.begin(), begin), _data.end());
+        std::reverse(std::next(_frameFiles.begin(), begin), _frameFiles.end());
         std::reverse(std::next(_delays.begin(), begin), _delays.end());
-        emit dataChanged(this->index(begin), this->index(_data.size() - 1));
+        emit dataChanged(this->index(begin), this->index(_frameFiles.size() - 1));
     } else {
-        std::reverse(std::next(_data.begin(), begin),
-                     std::next(_data.begin(), end));
+        std::reverse(std::next(_frameFiles.begin(), begin),
+                     std::next(_frameFiles.begin(), end));
         std::reverse(std::next(_delays.begin(), begin),
                      std::next(_delays.begin(), end));
         emit dataChanged(this->index(begin), this->index(end));
     }
+    _frameCache.clear();
     updateLinkedListViewCurrent();
 }
 
@@ -365,19 +446,20 @@ void GifContentModel::rotateFrames(bool clockwise) {
     QTransform trans;
     trans.rotate(clockwise ? -90 : 90);
 
-#ifdef Q_OS_WIN
-    concurrency::parallel_for_each(
-        _data.begin(), _data.end(), [&trans](QImage &img) {
-            img = img.transformed(trans, Qt::SmoothTransformation);
-        });
-#else
-#pragma omp parallel for
-    for (auto &img : _data) {
+    auto imgs = images();
+    QtConcurrent::blockingMap(imgs, [&trans](QImage &img) {
         img = img.transformed(trans, Qt::SmoothTransformation);
-    }
-#endif
+    });
 
-    emit dataChanged(this->index(0), this->index(_data.size() - 1));
+    if (!imgs.isEmpty()) {
+        _frameSize = imgs.first().size();
+    }
+
+    for (qsizetype i = 0; i < imgs.size(); ++i) {
+        persistFrame(i, imgs.at(i));
+    }
+
+    emit dataChanged(this->index(0), this->index(_frameFiles.size() - 1));
     updateLinkedListViewCurrent();
 }
 
@@ -394,7 +476,7 @@ void GifContentModel::moveFrames(qsizetype index, MoveFrameDirection dir,
         auto b = beginMoveRows(QModelIndex(), index, index + count - 1,
                                QModelIndex(), index - 1);
         Q_ASSERT(b);
-        moveRange(_data, index, index - 1, count);
+        moveRange(_frameFiles, index, index - 1, count);
         moveRange(_delays, index, index - 1, count);
     } break;
     case MoveFrameDirection::Right: {
@@ -404,16 +486,18 @@ void GifContentModel::moveFrames(qsizetype index, MoveFrameDirection dir,
         auto b = beginMoveRows(QModelIndex(), index, index + count - 1,
                                QModelIndex(), index + 2);
         Q_ASSERT(b);
-        moveRange(_data, index, index + 1, count);
+        moveRange(_frameFiles, index, index + 1, count);
         moveRange(_delays, index, index + 1, count);
     } break;
     }
 
+    _frameCache.clear();
     endMoveRows();
 }
 
 int GifContentModel::rowCount(const QModelIndex &parent) const {
-    return _data.size();
+    Q_UNUSED(parent);
+    return _frameFiles.size();
 }
 
 QVariant GifContentModel::data(const QModelIndex &index, int role) const {
@@ -423,7 +507,7 @@ QVariant GifContentModel::data(const QModelIndex &index, int role) const {
         return QString::number(_delays.at(i)) + QStringLiteral(" ms");
     }
     case Qt::DecorationRole: {
-        return _data.at(index.row());
+        return loadFrame(index.row());
     }
     case Qt::ToolTipRole: {
         break;

--- a/src/class/gifcontentmodel.h
+++ b/src/class/gifcontentmodel.h
@@ -21,8 +21,10 @@
 #include "gifreader.h"
 
 #include <QAbstractListModel>
+#include <QCache>
 #include <QListView>
 #include <QStyledItemDelegate>
+#include <QTemporaryDir>
 
 #include "control/gifeditor.h"
 #include "utilities.h"
@@ -106,6 +108,11 @@ private:
     void insertFrames(const QVector<QImage> &images, const QVector<int> &delays,
                       int index, bool processed);
 
+    bool ensureStoreDir();
+    QString framePathForIndex(qsizetype index) const;
+    void persistFrame(qsizetype index, const QImage &image);
+    QImage loadFrame(qsizetype index) const;
+
     template <typename T>
     void moveRange(QVector<T> &data, qsizetype pos, qsizetype dest,
                    qsizetype count = -1) {
@@ -123,7 +130,10 @@ public:
     virtual QVariant data(const QModelIndex &index, int role) const override;
 
 private:
-    QVector<QImage> _data;
+    QSize _frameSize;
+    QVector<QString> _frameFiles;
+    mutable QCache<qsizetype, QImage> _frameCache;
+    std::unique_ptr<QTemporaryDir> _storeDir;
     QVector<int> _delays;
 
     QListView *_view = nullptr;

--- a/src/class/gifreader.h
+++ b/src/class/gifreader.h
@@ -21,9 +21,13 @@
 #include "giflib/gif_lib.h"
 
 #include <QImage>
+#include <QCache>
 #include <QObject>
 #include <QString>
+#include <QTemporaryDir>
 #include <QVector>
+
+#include <memory>
 
 class GifReader : public QObject {
     Q_OBJECT
@@ -50,6 +54,8 @@ public:
 
     const QVector<QImage> images() const;
 
+    QString frameFilePath(qsizetype index) const;
+
     qsizetype imageCount() const;
 
     QString comment() const;
@@ -68,8 +74,11 @@ private:
 
 private:
     qsizetype m_framesCount = -1;
+    QSize m_frameSize;
     QVector<int> m_delays;
-    QVector<QImage> m_data;
+    QVector<QString> m_frameFiles;
+    mutable QCache<qsizetype, QImage> m_frameCache;
+    std::unique_ptr<QTemporaryDir> m_tmpDir;
     QString m_comment;
 };
 

--- a/src/class/gifwriter.h
+++ b/src/class/gifwriter.h
@@ -26,6 +26,7 @@
 #include <QString>
 
 #include <memory>
+#include <functional>
 
 class GifWriter : public QObject {
     Q_OBJECT
@@ -315,6 +316,10 @@ public:
     QImage image(qsizetype index) const;
 
     bool save(const QString &filename = QString(), unsigned int loopCount = 0);
+
+    bool saveLazy(const QString &filename, unsigned int loopCount,
+                  qsizetype frameCount, const QVector<int> &delays,
+                  const std::function<QImage(qsizetype)> &frameProvider);
 
     void clear();
 

--- a/src/control/gifeditor.h
+++ b/src/control/gifeditor.h
@@ -26,10 +26,15 @@
 class GifEditor : public QGraphicsView {
     Q_OBJECT
 public:
+    enum class DrawTool { None, Rectangle, Ellipse };
+
     GifEditor(const QImage &img, QWidget *parent = nullptr);
     void setImage(const QImage &img);
 
     QRectF selRect() const;
+
+    DrawTool drawTool() const;
+
 
 public slots:
     void setSelRect(int x, int y, int w, int h);
@@ -38,6 +43,8 @@ public slots:
     void fitInEditorView();
 
     void setCropMode(bool b);
+
+    void setDrawTool(DrawTool tool);
 
     void zoomIn();
     void zoomOut();
@@ -58,6 +65,9 @@ private:
     QRubberBand *rubber;
 
     QPoint tmppos;
+    QPointF drawStartPos;
+    QGraphicsItem *activeShape = nullptr;
+    DrawTool activeTool = DrawTool::None;
     bool iscut = true;
 };
 

--- a/src/control/gifeditorscene.cpp
+++ b/src/control/gifeditorscene.cpp
@@ -22,6 +22,7 @@
 #include <QAtomicInt>
 #include <QColor>
 #include <QHash>
+#include <QPainter>
 
 size_t qHash(const QColor &color, size_t seed = 0) noexcept {
     return qHash(qMakePair(color.rgba(), color.spec()), seed);
@@ -69,6 +70,20 @@ QRectF GifEditorScene::contentBounding() const { return gw->boundingRect(); }
 QSize GifEditorScene::frameImageSize() const { return sel->imageSize(); }
 
 QRectF GifEditorScene::selRect() const { return sel->selRect(); }
+
+QImage GifEditorScene::renderedImage() const {
+    auto imageSize = frameImageSize();
+    if (imageSize.isEmpty()) {
+        return {};
+    }
+
+    QImage rendered(imageSize, QImage::Format_ARGB32);
+    rendered.fill(Qt::transparent);
+
+    QPainter painter(&rendered);
+    this->render(&painter);
+    return rendered;
+}
 
 void GifEditorScene::setSelRect(int x, int y, int w, int h) {
     sel->setSelRect(x, y, w, h);

--- a/src/control/gifeditorscene.h
+++ b/src/control/gifeditorscene.h
@@ -38,6 +38,8 @@ public:
 
     QRectF selRect() const;
 
+    QImage renderedImage() const;
+
 public slots:
     void setSelRect(int x, int y, int w, int h);
 


### PR DESCRIPTION
### Motivation
- Reduce peak memory usage and enable editing of very large GIFs by avoiding loading all frames as `QImage` in memory at once. 
- Replace platform-specific parallel branches (OpenMP / PPL) with a single cross-platform `QtConcurrent` approach for image processing. 
- Provide simple, editable drawing tools (rectangle and ellipse) in the editor as a first step toward on-canvas drawing that can be persisted to frames. 

### Description
- Implemented disk-backed lazy frame storage in `GifReader` by writing frames to a temporary directory and keeping an LRU in-memory cache using `QCache`, plus frame path accessors (`src/class/gifreader.h`, `src/class/gifreader.cpp`). 
- Reworked `GifContentModel` to manage frames as file paths with on-demand loading and caching, persist edited frames back to the model temp store, and expose the same model API (`src/class/gifcontentmodel.h`, `src/class/gifcontentmodel.cpp`). 
- Added `GifWriter::saveLazy(...)` to stream frames from a frame-provider callback so the writer can write GIFs without holding all frames in memory, and adapted `save(...)` to reuse `saveLazy` (`src/class/gifwriter.h`, `src/class/gifwriter.cpp`). 
- Switched image-processing parallelism to `QtConcurrent::blockingMap` in the model and export paths (crop/scale/flip/rotate/export), and updated `CMakeLists.txt` to require/link `Qt::Concurrent` (`src/class/gifcontentmodel.cpp`, `src/dialog/mainwindow.cpp`, `CMakeLists.txt`). 
- Added simple drawing tools to the editor: `DrawTool` enum and APIs in `GifEditor`, interactive rectangle/ellipse creation and basic selectable/movable QGraphics items, and a `renderedImage()` helper in `GifEditorScene` for future persistence of drawings (`src/control/gifeditor.h`, `src/control/gifeditor.cpp`, `src/control/gifeditorscene.h`, `src/control/gifeditorscene.cpp`). 

### Testing
- Attempted an out-of-source CMake configure and build with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j4`, which failed at configuration because the CI/container environment does not have Qt development packages installed (missing `Qt6/Qt5` CMake packages). 
- Ran automated source inspections and quick grep checks (searching for `QtConcurrent`, `#pragma omp`, etc.) and inspected modified files to verify call-site changes and integration points, which succeeded as a static validation. 
- No unit or integration test runs were possible because a native Qt toolchain was not available in the execution environment, so runtime verification (compile + functional) remains to be performed on a machine with Qt development libraries installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a8dec46c832bab547dc386925f83)